### PR TITLE
Temporarily enable acceptance tests on main for #345

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -389,6 +389,7 @@ on:
   pull_request:
     branches:
     - master
+    - main
     - v*
     - feature*
     paths-ignore:


### PR DESCRIPTION
I'd like to see tests run on #345 before merging.
