### PR TITLE
Enable zero default schema version for tls

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -132,6 +132,7 @@ func Provider() tfbridge.ProviderInfo {
 				"tls": "Tls",
 			},
 		},
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	return info


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for tls.