### PR TITLE
Enable release verification

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -28,3 +28,9 @@ actions:
         cd provider && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
 pulumiConvert: 1
 registryDocs: true
+
+releaseVerification:
+  nodejs: private-key/ts
+  python: private-key/py
+  dotnet: private-key/dotnet
+  go: private-key/go

--- a/.github/workflows/build_provider.yml
+++ b/.github/workflows/build_provider.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       PROVIDER_VERSION: ${{ inputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AZURE_SIGNING_CONFIGURED: ${{ secrets.AZURE_SIGNING_CLIENT_ID != '' && secrets.AZURE_SIGNING_CLIENT_SECRET != '' && secrets.AZURE_SIGNING_TENANT_ID != '' && secrets.AZURE_SIGNING_KEY_VAULT_URI != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -52,15 +53,10 @@ jobs:
         run: make --touch provider schema
 
       - name: Build provider
-        if: matrix.platform.os != 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-tls
-
-      - name: Build windows provider
-        if: matrix.platform.os == 'windows'
-        run: make bin/${{ matrix.platform.os }}-${{ matrix.platform.arch }}/pulumi-resource-tls.exe
+        run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
 
       - name: Sign windows provider
-        if: matrix.platform.os == 'windows'
+        if: matrix.platform.os == 'windows' && env.AZURE_SIGNING_CONFIGURED == 'true'
         run: |
           az login --service-principal \
             -u ${{ secrets.AZURE_SIGNING_CLIENT_ID }} \

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -54,18 +54,13 @@ env:
 jobs:
   verify-release:
     name: verify-release
-    # We don't have any release verification configurations, so we never run this workflow.
-    # Configure your .ci-mgmt.yaml files to include the release verification configurations e.g.
-    # releaseVerification:
-    #   nodejs: path/to/nodejs/project
-    #   python: path/to/python/project
-    #   dotnet: path/to/dotnet/project
-    #   go: path/to/go/project
-    if: false
     strategy:
       matrix:
-        # We don't have any release verification configurations, so we only run on Linux to print warnings to help users configure the release verification.
-        runner: ["ubuntu-latest"]
+        # We always run on Linux and Windows, and optionally on MacOS. This is because MacOS runners have limited availability.
+        # Expression expands to ["ubuntu-latest","windows-latest"] or ["ubuntu-latest","windows-latest","macos-latest"]
+        # GitHub expressions don't have 'if' statements, so we use a ternary operator to conditionally include the MacOS runner suffix.
+        # See the docs for a similar example to this: https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
+        runner: ${{ fromJSON(format('["ubuntu-latest","windows-latest"{0}]', github.event.inputs.enableMacRunner == 'true' && ',"macos-latest"' || '')) }}
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout Repo
@@ -76,3 +71,32 @@ jobs:
         uses: ./.github/actions/setup-tools
         with:
           tools: pulumicli, nodejs, python, dotnet, go, java
+      - name: Verify nodejs release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: nodejs
+          directory: private-key/ts
+          provider: tls
+          providerVersion: ${{ inputs.providerVersion }}
+      - name: Verify python release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: python
+          directory: private-key/py
+          provider: tls
+          providerVersion: ${{ inputs.providerVersion }}
+      - name: Verify dotnet release
+        uses: pulumi/verify-provider-release@v1
+        with:
+          runtime: dotnet
+          directory: private-key/dotnet
+          provider: tls
+          providerVersion: ${{ inputs.providerVersion }}
+      - name: Verify go release
+        uses: pulumi/verify-provider-release@v1
+        if: inputs.skipGoSdk == false
+        with:
+          runtime: go
+          directory: private-key/go
+          provider: tls
+          providerVersion: ${{ inputs.providerVersion }}

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,13 @@ bin/%/$(PROVIDER) bin/%/$(PROVIDER).exe:
 		export CGO_ENABLED=0 && \
 		go build -o "${WORKING_DIR}/$@" $(PULUMI_PROVIDER_BUILD_PARALLELISM) -ldflags "$(LDFLAGS)" "$(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)"
 
+provider-linux-amd64: bin/linux-amd64/$(PROVIDER)
+provider-linux-arm64: bin/linux-arm64/$(PROVIDER)
+provider-darwin-amd64: bin/darwin-amd64/$(PROVIDER)
+provider-darwin-arm64: bin/darwin-arm64/$(PROVIDER)
+provider-windows-amd64: bin/windows-amd64/$(PROVIDER).exe
+.PHONY: provider-linux-amd64 provider-linux-arm64 provider-darwin-amd64 provider-darwin-arm64 provider-windows-amd64
+
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-amd64.tar.gz: bin/linux-amd64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-linux-arm64.tar.gz: bin/linux-arm64/$(PROVIDER)
 bin/$(PROVIDER)-v$(VERSION_GENERIC)-darwin-amd64.tar.gz: bin/darwin-amd64/$(PROVIDER)


### PR DESCRIPTION
As part of https://github.com/pulumi/ci-mgmt/issues/1201, we are enabling release verification on `pulumi-tls`.