### PR TITLE
Fix Go tests and release verification

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -5,7 +5,11 @@
 package examples
 
 import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
@@ -32,9 +36,18 @@ func TestAccSelfSignedCertGoForcesNewResource(t *testing.T) {
 
 func getGoBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions()
+	goDepRoot := os.Getenv("PULUMI_GO_DEP_ROOT")
+	if goDepRoot == "" {
+		var err error
+		goDepRoot, err = filepath.Abs("../..")
+		require.NoError(t, err)
+	}
 	baseGo := base.With(integration.ProgramTestOptions{
 		Dependencies: []string{
 			"github.com/pulumi/pulumi-tls/sdk/v5",
+		},
+		Env: []string{
+			fmt.Sprintf("PULUMI_GO_DEP_ROOT=%s", goDepRoot),
 		},
 	})
 

--- a/examples/private-key/go/go.mod
+++ b/examples/private-key/go/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.156.0
 )
 
-replace github.com/pulumi/pulumi-tls/sdk/v5 => ../../../sdk
-
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/examples/private-key/go/go.sum
+++ b/examples/private-key/go/go.sum
@@ -148,6 +148,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
 github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/pulumi-tls/sdk/v5 v5.0.0 h1:/NWY3ULKOShk42fT8/UwWnrDgOO0PnJ4nWqmytIK924=
+github.com/pulumi/pulumi-tls/sdk/v5 v5.0.0/go.mod h1:acQYWpx4TWf6Ye+vYzaY/OGOOz6ShsxXZd03FTlgAXI=
 github.com/pulumi/pulumi/sdk/v3 v3.156.0 h1:C4l4Z89EDft6aKe/ZmQYkZ8/7FUh/YvbKD4huIW4PoA=
 github.com/pulumi/pulumi/sdk/v3 v3.156.0/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/examples/self-signed-cert/go/go.mod
+++ b/examples/self-signed-cert/go/go.mod
@@ -43,8 +43,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 )
 
-replace github.com/pulumi/pulumi-tls/sdk/v5 => ../../../sdk
-
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect

--- a/examples/self-signed-cert/go/go.sum
+++ b/examples/self-signed-cert/go/go.sum
@@ -148,6 +148,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
 github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
+github.com/pulumi/pulumi-tls/sdk/v5 v5.0.0 h1:/NWY3ULKOShk42fT8/UwWnrDgOO0PnJ4nWqmytIK924=
+github.com/pulumi/pulumi-tls/sdk/v5 v5.0.0/go.mod h1:acQYWpx4TWf6Ye+vYzaY/OGOOz6ShsxXZd03FTlgAXI=
 github.com/pulumi/pulumi/sdk/v3 v3.156.0 h1:C4l4Z89EDft6aKe/ZmQYkZ8/7FUh/YvbKD4huIW4PoA=
 github.com/pulumi/pulumi/sdk/v3 v3.156.0/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
The Go tests had a `replace` statement in them. This breaks the verify-release action's expectations.

The good news here is that the last three releases weren't actually broken; but now the release verification does the right thing. Also added the ability to run the Go tests locally.

A separate run of the verify release job correctly verifies the latest release and shows this fix is working: https://github.com/pulumi/pulumi-tls/actions/runs/14063534937/job/39380119347

Fixes #741.

- **Remove replace statements from go.mod**
- **Make sure test can run locally**
