### PR TITLE
Use ComputeTokens for tls token mapping

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
-	"unicode"
 
 	_ "embed" // used to store bridge-metadata.json in the compiled binary
 
@@ -26,9 +25,9 @@ import (
 
 	pf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	tftokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
 	"github.com/pulumi/pulumi-tls/provider/v5/pkg/version"
 )
@@ -38,32 +37,6 @@ const (
 	tlsPkg = "tls"
 	tlsMod = "index"
 )
-
-// tlsMember manufactures a type token for the TLS package and the given module and type.
-func tlsMember(mod string, mem string) tokens.ModuleMember {
-	return tokens.ModuleMember(tlsPkg + ":" + mod + ":" + mem)
-}
-
-// tlsType manufactures a type token for the TLS package and the given module and type.
-func tlsType(mod string, typ string) tokens.Type {
-	return tokens.Type(tlsMember(mod, typ))
-}
-
-// tlsDataSource manufactures a standard resource token given a module and resource name.
-// It automatically uses the TLS package and names the file by simply lower casing the data
-// source's first character.
-func tlsDataSource(mod string, res string) tokens.ModuleMember {
-	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return tlsMember(mod+"/"+fn, res)
-}
-
-// tlsResource manufactures a standard resource token given a module and resource name.
-// It automatically uses the TLS package and names the file by simply lower casing the resource's
-// first character.
-func tlsResource(mod string, res string) tokens.Type {
-	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
-	return tlsType(mod+"/"+fn, res)
-}
 
 //go:embed cmd/pulumi-resource-tls/bridge-metadata.json
 var metadata []byte
@@ -83,18 +56,9 @@ func Provider() tfbridge.ProviderInfo {
 		GitHubOrg:    "hashicorp",
 		DocRules:     &tfbridge.DocRuleInfo{EditRules: docEditRules},
 		Resources: map[string]*tfbridge.ResourceInfo{
-			"tls_cert_request":        {Tok: tlsResource(tlsMod, "CertRequest")},
-			"tls_locally_signed_cert": {Tok: tlsResource(tlsMod, "LocallySignedCert")},
-			"tls_private_key":         {Tok: tlsResource(tlsMod, "PrivateKey")},
-
 			"tls_self_signed_cert": {
-				Tok:                 tlsResource(tlsMod, "SelfSignedCert"),
 				PreStateUpgradeHook: selfSignedCertPreStateUpgradeHook,
 			},
-		},
-		DataSources: map[string]*tfbridge.DataSourceInfo{
-			"tls_public_key":  {Tok: tlsDataSource(tlsMod, "getPublicKey")},
-			"tls_certificate": {Tok: tlsDataSource(tlsMod, "getCertificate")},
 		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			DevDependencies: map[string]string{
@@ -132,6 +96,12 @@ func Provider() tfbridge.ProviderInfo {
 		EnableZeroDefaultSchemaVersion: true,
 		EnableAccurateBridgePreview:    true,
 	}
+
+	info.MustComputeTokens(tftokens.SingleModule(
+		info.GetResourcePrefix()+"_",
+		tlsMod,
+		tftokens.MakeStandard(tlsPkg),
+	))
 
 	return info
 }

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -4,10 +4,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 
 	"github.com/pulumi/pulumi-tls/provider/v5/pkg/version"
 )

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,80 @@
+package tls
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-tls/provider/v5/pkg/version"
+)
+
+var setTestVersion sync.Once
+
+func providerInfoForTest() tfbridge.ProviderInfo {
+	setTestVersion.Do(func() {
+		version.Version = "5.0.0"
+	})
+	return Provider()
+}
+
+func TestProviderPreservesExistingTokens(t *testing.T) {
+	t.Parallel()
+
+	info := providerInfoForTest()
+
+	expectedResources := map[string]string{
+		"tls_cert_request":        "tls:index/certRequest:CertRequest",
+		"tls_locally_signed_cert": "tls:index/locallySignedCert:LocallySignedCert",
+		"tls_private_key":         "tls:index/privateKey:PrivateKey",
+		"tls_self_signed_cert":    "tls:index/selfSignedCert:SelfSignedCert",
+	}
+	for tfToken, want := range expectedResources {
+		resource, ok := info.Resources[tfToken]
+		require.Truef(t, ok, "missing resource mapping for %q", tfToken)
+		assert.Equal(t, want, string(resource.Tok))
+	}
+
+	expectedDataSources := map[string]string{
+		"tls_certificate": "tls:index/getCertificate:getCertificate",
+		"tls_public_key":  "tls:index/getPublicKey:getPublicKey",
+	}
+	for tfToken, want := range expectedDataSources {
+		dataSource, ok := info.DataSources[tfToken]
+		require.Truef(t, ok, "missing data source mapping for %q", tfToken)
+		assert.Equal(t, want, string(dataSource.Tok))
+	}
+
+	require.NotNil(t, info.Resources["tls_self_signed_cert"].PreStateUpgradeHook)
+}
+
+func TestProviderComputesTokensForAllUpstreamEntities(t *testing.T) {
+	t.Parallel()
+
+	info := providerInfoForTest()
+
+	resourceCount := 0
+	info.P.ResourcesMap().Range(func(key string, _ shim.Resource) bool {
+		resourceCount++
+
+		resource, ok := info.Resources[key]
+		require.Truef(t, ok, "missing resource mapping for upstream resource %q", key)
+		require.NotEmptyf(t, resource.Tok, "missing resource token for upstream resource %q", key)
+		return true
+	})
+	assert.Len(t, info.Resources, resourceCount)
+
+	dataSourceCount := 0
+	info.P.DataSourcesMap().Range(func(key string, _ shim.Resource) bool {
+		dataSourceCount++
+
+		dataSource, ok := info.DataSources[key]
+		require.Truef(t, ok, "missing data source mapping for upstream data source %q", key)
+		require.NotEmptyf(t, dataSource.Tok, "missing data source token for upstream data source %q", key)
+		return true
+	})
+	assert.Len(t, info.DataSources, dataSourceCount)
+}


### PR DESCRIPTION
## Summary
- switch `provider/resources.go` from hand-maintained token tables to `ComputeTokens(tokens.SingleModule(...))`
- preserve the existing `tls_self_signed_cert` pre-state-upgrade hook by keeping that resource as an explicit override
- add provider tests that lock the current public tokens and verify every upstream resource/data source gets a computed token

## Testing
- `cd provider && go test -short ./...`
- `make schema PULUMI_CONVERT=0`

Fixes #965